### PR TITLE
fix mate detection

### DIFF
--- a/engine/bitboard.cpp
+++ b/engine/bitboard.cpp
@@ -756,20 +756,20 @@ bool Board::threefold() {
 	return false;
 }
 
-bool Board::is_stalemate(pzstd::vector<Move> &moves) {
+uint8_t Board::ended(pzstd::vector<Move> &moves) { // 0 = not ended, 1 = checkmate, 2 = stalemate
 	bool check_for_side = side;
 	Square king_square = (Square)_tzcnt_u64(piece_boards[KING] & piece_boards[OCC(check_for_side)]);
-	bool in_check = (check_for_side == WHITE ? control(king_square).second : control(king_square).first);
-	if (in_check) return false; // King is currently in check therefore stalemate is impossible
+	bool in_check_base = (check_for_side == WHITE ? control(king_square).second : control(king_square).first);
 	for (const Move &move : moves) {
 		make_move(move);
 		king_square = (Square)_tzcnt_u64(piece_boards[KING] & piece_boards[OCC(check_for_side)]);
 		auto ks_control = control(king_square);
-		in_check = (check_for_side == WHITE ? ks_control.second : ks_control.first);
+		bool in_check = (check_for_side == WHITE ? ks_control.second : ks_control.first);
 		unmake_move();
 		if (!in_check) {
-			return false; // If we can make a move that doesn't put us in check, it's not stalemate
+			return 0;
 		}
 	}
-	return true;
+	if (!in_check_base) return 2;
+	return 1;
 }

--- a/engine/bitboard.hpp
+++ b/engine/bitboard.hpp
@@ -116,5 +116,5 @@ struct Board {
 	void recompute_hash();
 
 	bool threefold();
-	bool is_stalemate(pzstd::vector<Move> &);
+	uint8_t ended(pzstd::vector<Move> &);
 };

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -27,10 +27,10 @@ int main(int argc, char *argv[]) {
 			std::cout << "id name MonteCraplo " << VERSION << std::endl;
 			std::cout << "id author kevlu8 and wdotmathree" << std::endl;
 			std::cout << "uciok" << std::endl;
-		} else if (command == "isstale") {
+		} else if (command == "isend") {
 			auto legal_moves = pzstd::vector<Move>();
 			board.legal_moves(legal_moves);
-			std::cout << (board.is_stalemate(legal_moves) ? "true" : "false") << std::endl;
+			std::cout << (int)board.ended(legal_moves) << std::endl;
 			board.print_board();
 		} else if (command == "isready") {
 			std::cout << "readyok" << std::endl;


### PR DESCRIPTION
```
Elo   | 166.34 +- 52.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 10.00]
Games | N: 274 W: 198 L: 76 D: 0
Penta | [14, 0, 48, 0, 75]
```
https://sscg13.pythonanywhere.com/test/270/

- Introduces a lot more illegal moves